### PR TITLE
Setup GraphQL Server

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { graphqlHTTP } from 'express-graphql';
+import schema from './schema/schema.js'
 
 const app = express();
 
@@ -7,8 +8,9 @@ const port = 8080;
 
 app.use(express.json());
 
-app.use('/', (req, res) => {
-    res.json('Hi');
-});
+app.use('/data', graphqlHTTP({
+    schema,
+    graphiql: true,
+}));
 
 app.listen(port, () => {console.log(`Server listening on port ${process.env.PORT}`)});

--- a/server/app.js
+++ b/server/app.js
@@ -10,7 +10,7 @@ app.use(express.json());
 
 app.use('/data', graphqlHTTP({
     schema,
-    graphiql: true,
+    graphiql: true, // Remove when deploying
 }));
 
 app.listen(port, () => {console.log(`Server listening on port ${process.env.PORT}`)});

--- a/server/mockDatabase/data.js
+++ b/server/mockDatabase/data.js
@@ -1,13 +1,1 @@
-export let identities = [
-    {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
-    {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},
-    {id: '3', name: 'Kind person', description: 'A person who respects others'},
-    {id: '4', name: 'Handsome man'},
-]
-
-export let habits = [
-    {id: '1', name:'Study coding', description: 'Watch coding tutorials', identityId: '1'},
-    {id: '2', name:'Do side projects', identityId: '1'},
-    {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},
-    {id: '4', name:'Be nice', description: 'Smile always', identityId: '3'},
-]
+// The mock data inside data.js is moved to schema.js to enable mutation.

--- a/server/mockDatabase/data.js
+++ b/server/mockDatabase/data.js
@@ -1,0 +1,1 @@
+// The mock data inside data.js is moved to schema.js to enable mutation.

--- a/server/mockDatabase/data.js
+++ b/server/mockDatabase/data.js
@@ -1,1 +1,0 @@
-// The mock data inside data.js is moved to schema.js to enable mutation.

--- a/server/mockDatabase/data.js
+++ b/server/mockDatabase/data.js
@@ -1,11 +1,11 @@
-let identities = [
+export let identities = [
     {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
     {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},
     {id: '3', name: 'Kind person', description: 'A person who respects others'},
     {id: '4', name: 'Handsome man'},
 ]
 
-let habits = [
+export let habits = [
     {id: '1', name:'Study coding', description: 'Watch coding tutorials', identityId: '1'},
     {id: '2', name:'Do side projects', identityId: '1'},
     {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "apollo-server-errors": "^3.0.1",
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
-        "graphql": "^15.5.1"
+        "graphql": "^15.5.1",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/accepts": {
@@ -24,6 +26,17 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/apollo-server-errors": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.0.1.tgz",
+      "integrity": "sha512-PSp64IFeN1YK5EYZ3V/8iDRESMMyE00h1vE5aCr83wHL3T0mN7VRiMKoOIZ+2rUtnn7CpK73o6QLmouhxPtXsQ==",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0"
       }
     },
     "node_modules/array-flatten": {
@@ -565,6 +578,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -583,6 +604,12 @@
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
+    },
+    "apollo-server-errors": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.0.1.tgz",
+      "integrity": "sha512-PSp64IFeN1YK5EYZ3V/8iDRESMMyE00h1vE5aCr83wHL3T0mN7VRiMKoOIZ+2rUtnn7CpK73o6QLmouhxPtXsQ==",
+      "requires": {}
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -1005,6 +1032,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -10,8 +10,10 @@
   "author": "Jason Ko",
   "license": "ISC",
   "dependencies": {
+    "apollo-server-errors": "^3.0.1",
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
-    "graphql": "^15.5.1"
+    "graphql": "^15.5.1",
+    "uuid": "^8.3.2"
   }
 }

--- a/server/schema/dataType/habit/habit.js
+++ b/server/schema/dataType/habit/habit.js
@@ -1,0 +1,18 @@
+import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import IdentityType from "../identity/identity.js";
+
+const HabitType = new GraphQLObjectType({
+    name: 'Habit',
+    fields: () => ({
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        name: { type: new GraphQLNonNull(GraphQLString) },
+        description: { type: GraphQLString},
+        identityId: { type: new GraphQLNonNull(GraphQLID) },
+        identity: {
+            type: new GraphQLNonNull(IdentityType),
+            resolve: (parent, args) => (identities.find(identity => parent.identityId === identity.id))
+        }
+    }),
+});
+
+export default HabitType;

--- a/server/schema/dataType/identity/identity.js
+++ b/server/schema/dataType/identity/identity.js
@@ -1,0 +1,17 @@
+import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import HabitType from '../habit/habit.js'
+
+const IdentityType = new GraphQLObjectType({
+    name: 'Identity',
+    fields: () => ({
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        name: { type: new GraphQLNonNull(GraphQLString) },
+        description: { type: GraphQLString },
+        habits: {
+            type: new GraphQLList(HabitType),
+            resolve: (parent, args) => (habits.filter(habit => parent.id === habit.identityId)),
+        }
+    }),
+});
+
+export default IdentityType;

--- a/server/schema/schema.js
+++ b/server/schema/schema.js
@@ -1,11 +1,27 @@
-import { GraphQLID, GraphQLList, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
-import { identities, habits } from "../mockDatabase/data.js";
+import { UserInputError } from "apollo-server-errors";
+import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import { v4 as uuid } from 'uuid';
+
+
+let identities = [
+    {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
+    {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},
+    {id: '3', name: 'Kind person', description: 'A person who respects others'},
+    {id: '4', name: 'Handsome man'},
+]
+
+let habits = [
+    {id: '1', name:'Study coding', description: 'Watch coding tutorials', identityId: '1'},
+    {id: '2', name:'Do side projects', identityId: '1'},
+    {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},
+    {id: '4', name:'Be nice', description: 'Smile always', identityId: '3'},
+]
 
 const IdentityType = new GraphQLObjectType({
     name: 'Identity',
     fields: () => ({
-        id: { type: GraphQLID },
-        name: { type: GraphQLString },
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        name: { type: new GraphQLNonNull(GraphQLString) },
         description: { type: GraphQLString },
         habits: {
             type: new GraphQLList(HabitType),
@@ -17,12 +33,12 @@ const IdentityType = new GraphQLObjectType({
 const HabitType = new GraphQLObjectType({
     name: 'Habit',
     fields: () => ({
-        id: { type: GraphQLID },
-        name: { type: GraphQLString },
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        name: { type: new GraphQLNonNull(GraphQLString) },
         description: { type: GraphQLString},
-        identityId: { type: GraphQLID },
+        identityId: { type: new GraphQLNonNull(GraphQLID) },
         identity: {
-            type: IdentityType,
+            type: new GraphQLNonNull(IdentityType),
             resolve: (parent, args) => (identities.find(identity => parent.identityId === identity.id))
         }
     }),
@@ -33,7 +49,6 @@ const RootQuery = new GraphQLObjectType({
     fields: {
         identities: {
             type: new GraphQLList(IdentityType),
-            // TODO (Jason): Try to change resolve to arrow function
             resolve: (parent, args) => (identities),
         },
         identity: {
@@ -53,6 +68,78 @@ const RootQuery = new GraphQLObjectType({
     }
 });
 
+const Mutation = new GraphQLObjectType({
+    name: 'Mutation',
+    fields: {
+        // Add identity
+        addIdentity: {
+            type: IdentityType,
+            args: {
+                name: {type: new GraphQLNonNull(GraphQLString)},
+                description: {type: GraphQLString}
+            },
+            resolve: (parent, args) => {
+                const { name, description } = args;
+                if(!name) {
+                    return;
+                }
+                let newIdentity = { id: uuid() , name, description };
+                identities = [newIdentity, ... identities];
+                return newIdentity;
+            },
+        },
+        // Delete identity
+        deleteIdentity: {
+            type: new GraphQLList(IdentityType),
+            args: {
+                id: {type: new GraphQLNonNull(GraphQLID)},
+            },
+            resolve: (parent, args) => {
+                // delete identity
+                identities = identities.filter(identity => args.id !== identity.id)
+                // delete related habits
+                habits = habits.filter(habit => args.id !== habit.identityId);
+                return identities;
+            },
+        },
+        // Add habit
+        addHabit: {
+            type: HabitType,
+            args: {
+                name: {type: new GraphQLNonNull(GraphQLString)},
+                description: {type: GraphQLString},
+                identityId: {type: new GraphQLNonNull(GraphQLID)},
+            },
+            resolve: (parent, args) => {
+                const { name, description, identityId } = args;
+                if(!name || !identityId) {
+                    return;
+                }
+                const relatedIdentity = identities.find(identity => args.identityId === identity.id);
+                console.log(relatedIdentity);
+                if (!relatedIdentity) {
+                    throw new UserInputError("Invalid Identity Id");
+                }
+                let newHabit = { id: uuid() , name, description, identityId };
+                habits = [newHabit, ... habits];
+                return newHabit;
+            },
+        },
+        // Delete habit
+        deleteHabit: {
+            type: new GraphQLList(HabitType),
+            args: {
+                id: {type: new GraphQLNonNull(GraphQLID)},
+            },
+            resolve: (parent, args) => {
+                habits = habits.filter(habit => args.id !== habit.id)
+                return habits;
+            },
+        },
+    }
+})
+
 export default new GraphQLSchema({
     query: RootQuery,
+    mutation: Mutation,
 })

--- a/server/schema/schema.js
+++ b/server/schema/schema.js
@@ -1,6 +1,8 @@
 import { UserInputError } from "apollo-server-errors";
 import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
 import { v4 as uuid } from 'uuid';
+import IdentityType from './dataType/identity/identity.js';
+import HabitType from './dataType/habit/habit.js';
 
 let identities = [
     {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
@@ -15,33 +17,6 @@ let habits = [
     {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},
     {id: '4', name:'Be nice', description: 'Smile always', identityId: '3'},
 ]
-
-const IdentityType = new GraphQLObjectType({
-    name: 'Identity',
-    fields: () => ({
-        id: { type: new GraphQLNonNull(GraphQLID) },
-        name: { type: new GraphQLNonNull(GraphQLString) },
-        description: { type: GraphQLString },
-        habits: {
-            type: new GraphQLList(HabitType),
-            resolve: (parent, args) => (habits.filter(habit => parent.id === habit.identityId)),
-        }
-    }),
-});
-
-const HabitType = new GraphQLObjectType({
-    name: 'Habit',
-    fields: () => ({
-        id: { type: new GraphQLNonNull(GraphQLID) },
-        name: { type: new GraphQLNonNull(GraphQLString) },
-        description: { type: GraphQLString},
-        identityId: { type: new GraphQLNonNull(GraphQLID) },
-        identity: {
-            type: new GraphQLNonNull(IdentityType),
-            resolve: (parent, args) => (identities.find(identity => parent.identityId === identity.id))
-        }
-    }),
-});
 
 const RootQuery = new GraphQLObjectType({
     name: 'RootQuery',

--- a/server/schema/schema.js
+++ b/server/schema/schema.js
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 import IdentityType from './dataType/identity/identity.js';
 import HabitType from './dataType/habit/habit.js';
 
+
 let identities = [
     {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
     {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},

--- a/server/schema/schema.js
+++ b/server/schema/schema.js
@@ -2,7 +2,6 @@ import { UserInputError } from "apollo-server-errors";
 import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
 import { v4 as uuid } from 'uuid';
 
-
 let identities = [
     {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
     {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},

--- a/server/schema/schema.js
+++ b/server/schema/schema.js
@@ -1,0 +1,58 @@
+import { GraphQLID, GraphQLList, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import { identities, habits } from "../mockDatabase/data.js";
+
+const IdentityType = new GraphQLObjectType({
+    name: 'Identity',
+    fields: () => ({
+        id: { type: GraphQLID },
+        name: { type: GraphQLString },
+        description: { type: GraphQLString },
+        habits: {
+            type: new GraphQLList(HabitType),
+            resolve: (parent, args) => (habits.filter(habit => parent.id === habit.identityId)),
+        }
+    }),
+});
+
+const HabitType = new GraphQLObjectType({
+    name: 'Habit',
+    fields: () => ({
+        id: { type: GraphQLID },
+        name: { type: GraphQLString },
+        description: { type: GraphQLString},
+        identityId: { type: GraphQLID },
+        identity: {
+            type: IdentityType,
+            resolve: (parent, args) => (identities.find(identity => parent.identityId === identity.id))
+        }
+    }),
+});
+
+const RootQuery = new GraphQLObjectType({
+    name: 'RootQuery',
+    fields: {
+        identities: {
+            type: new GraphQLList(IdentityType),
+            // TODO (Jason): Try to change resolve to arrow function
+            resolve: (parent, args) => (identities),
+        },
+        identity: {
+            type: IdentityType,
+            args:{ id: { type: GraphQLID }},
+            resolve: (parent, args) => (identities.find(identity => args.id === identity.id)),
+        },
+        habits: {
+            type: new GraphQLList(HabitType),
+            resolve: (parent, args) => (habits),
+        },
+        habit: {
+            type: HabitType,
+            args:{ id: { type: GraphQLID }},
+            resolve: (parent, args) => (habits.find(habit => args.id === habit.id)),
+        },
+    }
+});
+
+export default new GraphQLSchema({
+    query: RootQuery,
+})


### PR DESCRIPTION
Issue: Set up GraphQL schema and datatypes, query, mutation.
Solution: Add identity and habit datatypes, query, add/delete mutation.
Risk: Due to schema modularization, it will cause error when executing mutation due to read-only nature of exported variables. Database must be set up before executing mutation for function correctly.
Reviewed by: Jason Ko
