### PR TITLE
Implement GraphQL server and MongoDB Atlas database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,338 @@
+{
+  "name": "Todo-App",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "mongodb": "^4.1.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "16.4.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
+      "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bson": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.4.1.tgz",
+      "integrity": "sha512-Uu4OCZa0jouQJCKOk1EmmyqtdWAP5HVLru4lQxTwzJzxT+sJ13lVpEZU/MATDxtHiekWMAL84oQY3Xn1LpJVSg==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
+    "node_modules/mongodb": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.0.tgz",
+      "integrity": "sha512-Gx9U9MsFWgJ3E0v4oHAdWvYTGBznNYPCkhmD/3i/kPTY/URnPfHD5/6VoKUFrdgQTK3icFiM9976hVbqCRBO9Q==",
+      "dependencies": {
+        "bson": "^4.4.0",
+        "denque": "^1.5.0",
+        "mongodb-connection-string-url": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-1.1.2.tgz",
+      "integrity": "sha512-mp5lv4guWuykOpkwNNqQ0tKKytuJUjL/aC/bu/DqoJVWL5NSh4j/u+gJ+EiOdweLujHyq6JZZqcTVipHhL5xRg==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.0.0",
+        "whatwg-url": "^8.4.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/node": {
+      "version": "16.4.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
+      "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg=="
+    },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bson": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.4.1.tgz",
+      "integrity": "sha512-Uu4OCZa0jouQJCKOk1EmmyqtdWAP5HVLru4lQxTwzJzxT+sJ13lVpEZU/MATDxtHiekWMAL84oQY3Xn1LpJVSg==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
+    "mongodb": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.0.tgz",
+      "integrity": "sha512-Gx9U9MsFWgJ3E0v4oHAdWvYTGBznNYPCkhmD/3i/kPTY/URnPfHD5/6VoKUFrdgQTK3icFiM9976hVbqCRBO9Q==",
+      "requires": {
+        "bson": "^4.4.0",
+        "denque": "^1.5.0",
+        "mongodb-connection-string-url": "^1.0.1",
+        "saslprep": "^1.0.0"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-1.1.2.tgz",
+      "integrity": "sha512-mp5lv4guWuykOpkwNNqQ0tKKytuJUjL/aC/bu/DqoJVWL5NSh4j/u+gJ+EiOdweLujHyq6JZZqcTVipHhL5xRg==",
+      "requires": {
+        "@types/whatwg-url": "^8.0.0",
+        "whatwg-url": "^8.4.0"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+    },
+    "whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "requires": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "mongodb": "^4.1.0"
+  }
+}

--- a/server/app.js
+++ b/server/app.js
@@ -1,9 +1,9 @@
-import express from 'express';
-import { graphqlHTTP } from 'express-graphql';
-import schema from './schema/schema.js'
-import dotenv from 'dotenv'
-import { addHabit, connectDB } from './database/database.js';
-dotenv.config()
+import express from "express";
+import { graphqlHTTP } from "express-graphql";
+import schema from "./schema/schema.js";
+import dotenv from "dotenv";
+import { addHabit, connectDB } from "./database/database.js";
+dotenv.config();
 
 const app = express();
 
@@ -11,14 +11,19 @@ const port = process.env.PORT;
 
 app.use(express.json());
 
-app.use('/data', graphqlHTTP({
+app.use(
+  "/data",
+  graphqlHTTP({
     schema,
     graphiql: true, // TODO(Jason): Remove when deploying
-}));
+  })
+);
 
 // If connection to DB is successful, then listen
 connectDB()
-    .then(() => {
-        app.listen(port, () => {console.log(`Server listening on port ${process.env.PORT}`)});
-    })
-    .catch(console.error);
+  .then(() => {
+    app.listen(port, () => {
+      console.log(`Server listening on port ${process.env.PORT}`);
+    });
+  })
+  .catch(console.error);

--- a/server/app.js
+++ b/server/app.js
@@ -1,16 +1,24 @@
 import express from 'express';
 import { graphqlHTTP } from 'express-graphql';
 import schema from './schema/schema.js'
+import dotenv from 'dotenv'
+import { addHabit, connectDB } from './database/database.js';
+dotenv.config()
 
 const app = express();
 
-const port = 8080;
+const port = process.env.PORT;
 
 app.use(express.json());
 
 app.use('/data', graphqlHTTP({
     schema,
-    graphiql: true, // Remove when deploying
+    graphiql: true, // TODO(Jason): Remove when deploying
 }));
 
-app.listen(port, () => {console.log(`Server listening on port ${process.env.PORT}`)});
+// If connection to DB is successful, then listen
+connectDB()
+    .then(() => {
+        app.listen(port, () => {console.log(`Server listening on port ${process.env.PORT}`)});
+    })
+    .catch(console.error);

--- a/server/database/database.js
+++ b/server/database/database.js
@@ -1,0 +1,89 @@
+import { MongoClient } from 'mongodb';
+import assert from 'assert';
+
+let database;
+let habitCollection;
+let identityCollection;
+export async function connectDB() {
+    const client = new MongoClient(process.env.DB_HOST, {
+         useNewUrlParser: true, useUnifiedTopology: true 
+    });
+    await client.connect();
+    database = await client.db("Todo");
+    habitCollection = await database.collection("habits")
+    // .insertMany([
+    //     {id: '1', name:'Study coding', description: 'Watch coding tutorials', identityId: '1'},
+    //     {id: '2', name:'Do side projects', identityId: '1'},
+    //     {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},
+    //     {id: '4', name:'Be nice', description: 'Smile always', identityId: '3'}
+    // ])
+    identityCollection = await database.collection("identities")
+    // .insertMany([
+    //     {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
+    //     {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},
+    //     {id: '3', name: 'Kind person', description: 'A person who respects others'},
+    //     {id: '4', name: 'Handsome man'}
+    // ]);
+}
+
+function mapArrayToRemoveMongoId(identities) {
+    return identities.map(identity => {
+        delete identity["_id"];
+        return identity;
+    })
+}
+
+// Identity
+export async function addIdentity(identity) {
+    identityCollection.insertOne(identity);
+}
+
+export async function getAllIdentities() {
+    return await identityCollection
+        .find()
+        .toArray()
+        .then(mapArrayToRemoveMongoId)
+}
+
+export async function getIdentityById(id) {
+    return await identityCollection.find({id}).next();
+}
+
+export async function removeIdentity(id) {
+    await identityCollection.deleteOne({id});
+}
+
+// Habit
+export async function addHabit(habit) {
+    const identity = await getIdentityById(habit.identityId);
+    if(identity) {
+        habitCollection.insertOne(habit);
+    }
+}
+
+export async function getAllHabits() {
+    return await habitCollection
+        .find()
+        .toArray()
+        .then(mapArrayToRemoveMongoId)
+}
+
+export async function getHabitsWithIdentityId(identityId) {
+    return await habitCollection
+        .find({identityId})
+        .toArray()
+        .then(mapArrayToRemoveMongoId)
+}
+
+export async function getHabitById(id) {
+    return await habitCollection.find({id}).next();
+}
+
+export async function removeHabit(id) {
+    await habitCollection.deleteOne({id});
+}
+
+export async function removeHabitsWithIdentityId(identityId) {
+    await habitCollection.deleteMany({identityId});
+}
+

--- a/server/database/database.js
+++ b/server/database/database.js
@@ -1,89 +1,86 @@
-import { MongoClient } from 'mongodb';
-import assert from 'assert';
+import { MongoClient } from "mongodb";
+import assert from "assert";
 
 let database;
 let habitCollection;
 let identityCollection;
 export async function connectDB() {
-    const client = new MongoClient(process.env.DB_HOST, {
-         useNewUrlParser: true, useUnifiedTopology: true 
-    });
-    await client.connect();
-    database = await client.db("Todo");
-    habitCollection = await database.collection("habits")
-    // .insertMany([
-    //     {id: '1', name:'Study coding', description: 'Watch coding tutorials', identityId: '1'},
-    //     {id: '2', name:'Do side projects', identityId: '1'},
-    //     {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},
-    //     {id: '4', name:'Be nice', description: 'Smile always', identityId: '3'}
-    // ])
-    identityCollection = await database.collection("identities")
-    // .insertMany([
-    //     {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
-    //     {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},
-    //     {id: '3', name: 'Kind person', description: 'A person who respects others'},
-    //     {id: '4', name: 'Handsome man'}
-    // ]);
+  const client = new MongoClient(process.env.DB_HOST, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+  await client.connect();
+  database = await client.db("Todo");
+  habitCollection = await database.collection("habits");
+  // .insertMany([
+  //     {id: '1', name:'Study coding', description: 'Watch coding tutorials', identityId: '1'},
+  //     {id: '2', name:'Do side projects', identityId: '1'},
+  //     {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},
+  //     {id: '4', name:'Be nice', description: 'Smile always', identityId: '3'}
+  // ])
+  identityCollection = await database.collection("identities");
+  // .insertMany([
+  //     {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
+  //     {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},
+  //     {id: '3', name: 'Kind person', description: 'A person who respects others'},
+  //     {id: '4', name: 'Handsome man'}
+  // ]);
 }
 
 function mapArrayToRemoveMongoId(identities) {
-    return identities.map(identity => {
-        delete identity["_id"];
-        return identity;
-    })
+  return identities.map((identity) => {
+    delete identity["_id"];
+    return identity;
+  });
 }
 
 // Identity
 export async function addIdentity(identity) {
-    identityCollection.insertOne(identity);
+  identityCollection.insertOne(identity);
 }
 
 export async function getAllIdentities() {
-    return await identityCollection
-        .find()
-        .toArray()
-        .then(mapArrayToRemoveMongoId)
+  return await identityCollection
+    .find()
+    .toArray()
+    .then(mapArrayToRemoveMongoId);
 }
 
 export async function getIdentityById(id) {
-    return await identityCollection.find({id}).next();
+  return await identityCollection.find({ id }).next();
 }
 
 export async function removeIdentity(id) {
-    await identityCollection.deleteOne({id});
+  await identityCollection.deleteOne({ id });
 }
 
 // Habit
 export async function addHabit(habit) {
-    const identity = await getIdentityById(habit.identityId);
-    if(identity) {
-        habitCollection.insertOne(habit);
-    }
+  const identity = await getIdentityById(habit.identityId);
+  if (identity) {
+    habitCollection.insertOne(habit);
+  }
 }
 
 export async function getAllHabits() {
-    return await habitCollection
-        .find()
-        .toArray()
-        .then(mapArrayToRemoveMongoId)
+  return await habitCollection.find().toArray().then(mapArrayToRemoveMongoId);
 }
 
 export async function getHabitsWithIdentityId(identityId) {
-    return await habitCollection
-        .find({identityId})
-        .toArray()
-        .then(mapArrayToRemoveMongoId)
+  return await habitCollection
+    .find({ identityId })
+    .toArray()
+    .then(mapArrayToRemoveMongoId);
 }
 
 export async function getHabitById(id) {
-    return await habitCollection.find({id}).next();
+  return await habitCollection.find({ id }).next();
 }
 
 export async function removeHabit(id) {
-    await habitCollection.deleteOne({id});
+  await habitCollection.deleteOne({ id });
 }
 
 export async function removeHabitsWithIdentityId(identityId) {
-    await habitCollection.deleteMany({identityId});
+  await habitCollection.deleteMany({ identityId });
 }
-

--- a/server/mockDatabase/data.js
+++ b/server/mockDatabase/data.js
@@ -1,14 +1,32 @@
 // Mock data is left for testing purpose
 let identities = [
-    {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
-    {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},
-    {id: '3', name: 'Kind person', description: 'A person who respects others'},
-    {id: '4', name: 'Handsome man'}
-]
+  {
+    id: "1",
+    name: "Best developer",
+    description: "The best programmer in the world",
+  },
+  {
+    id: "2",
+    name: "Healthy person",
+    description: "A person who is fit and healthy",
+  },
+  { id: "3", name: "Kind person", description: "A person who respects others" },
+  { id: "4", name: "Handsome man" },
+];
 
 let habits = [
-    {id: '1', name:'Study coding', description: 'Watch coding tutorials', identityId: '1'},
-    {id: '2', name:'Do side projects', identityId: '1'},
-    {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},
-    {id: '4', name:'Be nice', description: 'Smile always', identityId: '3'}
-]
+  {
+    id: "1",
+    name: "Study coding",
+    description: "Watch coding tutorials",
+    identityId: "1",
+  },
+  { id: "2", name: "Do side projects", identityId: "1" },
+  {
+    id: "3",
+    name: "Eat healthy",
+    description: "No junk food!",
+    identityId: "2",
+  },
+  { id: "4", name: "Be nice", description: "Smile always", identityId: "3" },
+];

--- a/server/mockDatabase/data.js
+++ b/server/mockDatabase/data.js
@@ -1,0 +1,13 @@
+let identities = [
+    {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
+    {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},
+    {id: '3', name: 'Kind person', description: 'A person who respects others'},
+    {id: '4', name: 'Handsome man'},
+]
+
+let habits = [
+    {id: '1', name:'Study coding', description: 'Watch coding tutorials', identityId: '1'},
+    {id: '2', name:'Do side projects', identityId: '1'},
+    {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},
+    {id: '4', name:'Be nice', description: 'Smile always', identityId: '3'},
+]

--- a/server/mockDatabase/data.js
+++ b/server/mockDatabase/data.js
@@ -1,1 +1,14 @@
-// The mock data inside data.js is moved to schema.js to enable mutation.
+// Mock data is left for testing purpose
+let identities = [
+    {id: '1', name: 'Best developer', description: 'The best programmer in the world'},
+    {id: '2', name: 'Healthy person', description: 'A person who is fit and healthy'},
+    {id: '3', name: 'Kind person', description: 'A person who respects others'},
+    {id: '4', name: 'Handsome man'}
+]
+
+let habits = [
+    {id: '1', name:'Study coding', description: 'Watch coding tutorials', identityId: '1'},
+    {id: '2', name:'Do side projects', identityId: '1'},
+    {id: '3', name:'Eat healthy', description: 'No junk food!', identityId: '2'},
+    {id: '4', name:'Be nice', description: 'Smile always', identityId: '3'}
+]

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "apollo-server-errors": "^3.0.1",
+        "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
         "graphql": "^15.5.1",
@@ -124,6 +125,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -678,6 +687,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "apollo-server-errors": "^3.0.1",
+    "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
     "graphql": "^15.5.1",

--- a/server/schema/dataType/habit/habit.js
+++ b/server/schema/dataType/habit/habit.js
@@ -1,19 +1,26 @@
-import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import {
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+} from "graphql";
 import { getIdentityById } from "../../../database/database.js";
 import IdentityType from "../identity/identity.js";
 
 const HabitType = new GraphQLObjectType({
-    name: 'Habit',
-    fields: () => ({
-        id: { type: new GraphQLNonNull(GraphQLID) },
-        name: { type: new GraphQLNonNull(GraphQLString) },
-        description: { type: GraphQLString},
-        identityId: { type: new GraphQLNonNull(GraphQLID) },
-        identity: {
-            type: new GraphQLNonNull(IdentityType),
-            resolve: (parent, args) => getIdentityById(parent.identityId)
-        }
-    }),
+  name: "Habit",
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLID) },
+    name: { type: new GraphQLNonNull(GraphQLString) },
+    description: { type: GraphQLString },
+    identityId: { type: new GraphQLNonNull(GraphQLID) },
+    identity: {
+      type: new GraphQLNonNull(IdentityType),
+      resolve: (parent, args) => getIdentityById(parent.identityId),
+    },
+  }),
 });
 
 export default HabitType;

--- a/server/schema/dataType/habit/habit.js
+++ b/server/schema/dataType/habit/habit.js
@@ -1,4 +1,5 @@
 import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import { getIdentityById } from "../../../database/database.js";
 import IdentityType from "../identity/identity.js";
 
 const HabitType = new GraphQLObjectType({
@@ -10,7 +11,7 @@ const HabitType = new GraphQLObjectType({
         identityId: { type: new GraphQLNonNull(GraphQLID) },
         identity: {
             type: new GraphQLNonNull(IdentityType),
-            resolve: (parent, args) => (identities.find(identity => parent.identityId === identity.id))
+            resolve: (parent, args) => getIdentityById(parent.identityId)
         }
     }),
 });

--- a/server/schema/dataType/identity/identity.js
+++ b/server/schema/dataType/identity/identity.js
@@ -1,4 +1,5 @@
 import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import { getHabitsWithIdentityId } from "../../../database/database.js";
 import HabitType from '../habit/habit.js'
 
 const IdentityType = new GraphQLObjectType({
@@ -9,7 +10,7 @@ const IdentityType = new GraphQLObjectType({
         description: { type: GraphQLString },
         habits: {
             type: new GraphQLList(HabitType),
-            resolve: (parent, args) => (habits.filter(habit => parent.id === habit.identityId)),
+            resolve: (parent, args) => getHabitsWithIdentityId(parent.id)
         }
     }),
 });

--- a/server/schema/dataType/identity/identity.js
+++ b/server/schema/dataType/identity/identity.js
@@ -1,18 +1,25 @@
-import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import {
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+} from "graphql";
 import { getHabitsWithIdentityId } from "../../../database/database.js";
-import HabitType from '../habit/habit.js'
+import HabitType from "../habit/habit.js";
 
 const IdentityType = new GraphQLObjectType({
-    name: 'Identity',
-    fields: () => ({
-        id: { type: new GraphQLNonNull(GraphQLID) },
-        name: { type: new GraphQLNonNull(GraphQLString) },
-        description: { type: GraphQLString },
-        habits: {
-            type: new GraphQLList(HabitType),
-            resolve: (parent, args) => getHabitsWithIdentityId(parent.id)
-        }
-    }),
+  name: "Identity",
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLID) },
+    name: { type: new GraphQLNonNull(GraphQLString) },
+    description: { type: GraphQLString },
+    habits: {
+      type: new GraphQLList(HabitType),
+      resolve: (parent, args) => getHabitsWithIdentityId(parent.id),
+    },
+  }),
 });
 
 export default IdentityType;

--- a/server/schema/schema.js
+++ b/server/schema/schema.js
@@ -1,103 +1,121 @@
-import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
-import { v4 as uuid } from 'uuid';
-import IdentityType from './dataType/identity/identity.js';
-import HabitType from './dataType/habit/habit.js';
-import { addHabit, addIdentity, getIdentityById, getAllHabits, getAllIdentities, getHabitById, removeIdentity, removeHabit, getHabitsWithIdentityId, removeHabitsWithIdentityId } from "../database/database.js";
+import {
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+} from "graphql";
+import { v4 as uuid } from "uuid";
+import IdentityType from "./dataType/identity/identity.js";
+import HabitType from "./dataType/habit/habit.js";
+import {
+  addHabit,
+  addIdentity,
+  getIdentityById,
+  getAllHabits,
+  getAllIdentities,
+  getHabitById,
+  removeIdentity,
+  removeHabit,
+  getHabitsWithIdentityId,
+  removeHabitsWithIdentityId,
+} from "../database/database.js";
 
 const RootQuery = new GraphQLObjectType({
-    name: 'RootQuery',
-    fields: {
-        identities: {
-            type: new GraphQLList(IdentityType),
-            resolve: (parent, args) => getAllIdentities(),
-        },
-        identity: {
-            type: IdentityType,
-            args:{ id: { type: GraphQLID }},
-            resolve: (parent, args) => getIdentityById(args.id),
-        },
-        habits: {
-            type: new GraphQLList(HabitType),
-            resolve: (parent, args) => getAllHabits(),
-        },
-        habit: {
-            type: HabitType,
-            args:{ id: { type: GraphQLID }},
-            resolve: (parent, args) => getHabitById(args.id),
-        },
-    }
+  name: "RootQuery",
+  fields: {
+    identities: {
+      type: new GraphQLList(IdentityType),
+      resolve: (parent, args) => getAllIdentities(),
+    },
+    identity: {
+      type: IdentityType,
+      args: { id: { type: GraphQLID } },
+      resolve: (parent, args) => getIdentityById(args.id),
+    },
+    habits: {
+      type: new GraphQLList(HabitType),
+      resolve: (parent, args) => getAllHabits(),
+    },
+    habit: {
+      type: HabitType,
+      args: { id: { type: GraphQLID } },
+      resolve: (parent, args) => getHabitById(args.id),
+    },
+  },
 });
 
 const Mutation = new GraphQLObjectType({
-    name: 'Mutation',
-    fields: {
-        // Add identity
-        addIdentity: {
-            type: IdentityType,
-            args: {
-                name: {type: new GraphQLNonNull(GraphQLString)},
-                description: {type: GraphQLString}
-            },
-            resolve: (parent, args) => {
-                const { name, description } = args;
-                // Check if name is given
-                if(!name) {
-                    return;
-                }
-                // Create new Identity
-                let newIdentity = { id: uuid() , name, description };
+  name: "Mutation",
+  fields: {
+    // Add identity
+    addIdentity: {
+      type: IdentityType,
+      args: {
+        name: { type: new GraphQLNonNull(GraphQLString) },
+        description: { type: GraphQLString },
+      },
+      resolve: (parent, args) => {
+        const { name, description } = args;
+        // Check if name is given
+        if (!name) {
+          return;
+        }
+        // Create new Identity
+        let newIdentity = { id: uuid(), name, description };
 
-                // Insert to DB
-                addIdentity(newIdentity);
-                return newIdentity;
-            },
-        },
-        // Delete identity
-        deleteIdentity: {
-            type: new GraphQLList(IdentityType),
-            args: {
-                id: {type: new GraphQLNonNull(GraphQLID)},
-            },
-            resolve: (parent, args) => {
-                removeIdentity(args.id);
-                removeHabitsWithIdentityId(args.id);
-                return getAllIdentities();
-            },
-        },
-        // Add habit
-        addHabit: {
-            type: HabitType,
-            args: {
-                name: {type: new GraphQLNonNull(GraphQLString)},
-                description: {type: GraphQLString},
-                identityId: {type: new GraphQLNonNull(GraphQLID)},
-            },
-            resolve: (parent, args) => {
-                const { name, description, identityId } = args;
-                // Check if name and identityID is given
-                if(!name || !identityId) {
-                    return;
-                }
-                let newHabit = { id: uuid() , name, description, identityId };
-                addHabit(newHabit);
-                return newHabit;
-            },
-        },
-        // Delete habit
-        deleteHabit: {
-            type: new GraphQLList(HabitType),
-            args: {
-                id: {type: new GraphQLNonNull(GraphQLID)},
-            },
-            resolve: (parent, args) => {
-                removeHabit(args.id);
-                return getAllHabits();
-            },
-        },
-    }
-})
+        // Insert to DB
+        addIdentity(newIdentity);
+        return newIdentity;
+      },
+    },
+    // Delete identity
+    deleteIdentity: {
+      type: new GraphQLList(IdentityType),
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+      },
+      resolve: (parent, args) => {
+        removeIdentity(args.id);
+        removeHabitsWithIdentityId(args.id);
+        return getAllIdentities();
+      },
+    },
+    // Add habit
+    addHabit: {
+      type: HabitType,
+      args: {
+        name: { type: new GraphQLNonNull(GraphQLString) },
+        description: { type: GraphQLString },
+        identityId: { type: new GraphQLNonNull(GraphQLID) },
+      },
+      resolve: (parent, args) => {
+        const { name, description, identityId } = args;
+        // Check if name and identityID is given
+        if (!name || !identityId) {
+          return;
+        }
+        let newHabit = { id: uuid(), name, description, identityId };
+        addHabit(newHabit);
+        return newHabit;
+      },
+    },
+    // Delete habit
+    deleteHabit: {
+      type: new GraphQLList(HabitType),
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+      },
+      resolve: (parent, args) => {
+        removeHabit(args.id);
+        return getAllHabits();
+      },
+    },
+  },
+});
 
 export default new GraphQLSchema({
-    query: RootQuery,
-    mutation: Mutation,
-})
+  query: RootQuery,
+  mutation: Mutation,
+});


### PR DESCRIPTION
Implement GraphQL server and MongoDB Atlas database

Issue: Implement GraphQL server and MongoDB Atlas database.
Solution: Implement server using GraphQL, Node.js and Express. Connect to MongoDB Atlas database.
Risk: Adding new habit with invalid identity id using GraphQL query needs to show error in the font end.
Reviewed by: Jason Ko. 