### PR TITLE
Turn closeModal into context

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -8,6 +8,7 @@ import NewHabitModal from "./components/newHabitModal/newHabitModal";
 import NewIdentityModal from "./components/newIdentityModal/newIdentityModal";
 import HabitDetailModal from "./components/habitDetailModal/habitDetailModal";
 import IdentityDetailModal from "./components/identityDetailModal/identityDetailModal";
+import { CloseModalContext } from "./context/modalContext";
 
 function App({ habitService, identityService }) {
   // Modal Types
@@ -106,36 +107,32 @@ function App({ habitService, identityService }) {
           </Route>
         </Switch>
       </Router>
-      {isModalOpen && (
-        <ModalWrapper closeModal={closeModal}>
-          {modalType === MODAL_TYPE_ADD_HABIT && (
-            <NewHabitModal
-              closeModal={closeModal}
-              addNewHabit={habitService.addNewHabit}
-            />
-          )}
-          {modalType === MODAL_TYPE_ADD_IDENTITY && (
-            <NewIdentityModal
-              closeModal={closeModal}
-              addNewIdentity={identityService.addNewIdentity}
-            />
-          )}
-          {modalType === MODAL_TYPE_HABIT_DETAIL && (
-            <HabitDetailModal
-              closeModal={closeModal}
-              currentCard={currentHabitCard}
-              deleteCard={deleteHabit}
-            />
-          )}
-          {modalType === MODAL_TYPE_IDENTITY_DETAIL && (
-            <IdentityDetailModal
-              closeModal={closeModal}
-              currentCard={currentIdentityCard}
-              deleteCard={deleteIdentity}
-            />
-          )}
-        </ModalWrapper>
-      )}
+      <CloseModalContext.Provider value={closeModal}>
+        {isModalOpen && (
+          <ModalWrapper>
+            {modalType === MODAL_TYPE_ADD_HABIT && (
+              <NewHabitModal addNewHabit={habitService.addNewHabit} />
+            )}
+            {modalType === MODAL_TYPE_ADD_IDENTITY && (
+              <NewIdentityModal
+                addNewIdentity={identityService.addNewIdentity}
+              />
+            )}
+            {modalType === MODAL_TYPE_HABIT_DETAIL && (
+              <HabitDetailModal
+                currentCard={currentHabitCard}
+                deleteCard={deleteHabit}
+              />
+            )}
+            {modalType === MODAL_TYPE_IDENTITY_DETAIL && (
+              <IdentityDetailModal
+                currentCard={currentIdentityCard}
+                deleteCard={deleteIdentity}
+              />
+            )}
+          </ModalWrapper>
+        )}
+      </CloseModalContext.Provider>
     </div>
   );
 }

--- a/frontend/src/components/closeButton/closeButton.jsx
+++ b/frontend/src/components/closeButton/closeButton.jsx
@@ -1,10 +1,14 @@
-import React from "react";
+import React, { useContext } from "react";
+import { CloseModalContext } from "../../context/modalContext";
 import styles from "./closeButton.module.css";
 
-const CloseButton = ({ closeModal }) => (
-  <button onClick={closeModal} className={styles.closeButton}>
-    X
-  </button>
-);
+const CloseButton = () => {
+  const closeModal = useContext(CloseModalContext);
+  return (
+    <button onClick={closeModal} className={styles.closeButton}>
+      X
+    </button>
+  );
+};
 
 export default CloseButton;

--- a/frontend/src/components/common/addNewForm/addNewForm.jsx
+++ b/frontend/src/components/common/addNewForm/addNewForm.jsx
@@ -1,11 +1,14 @@
-import React from "react";
+import React, { useContext } from "react";
 import styles from "./addNewForm.module.css";
 import {
   validateIdentity,
   validateHabit,
 } from "../../../validators/validators";
+import { CloseModalContext } from "../../../context/modalContext";
 
-const AddNewForm = ({ type, submitHandler, closeModal }) => {
+const AddNewForm = ({ type, submitHandler }) => {
+  const closeModal = useContext(CloseModalContext);
+
   let formName;
   if (type === "habit") {
     formName = "addHabitForm";

--- a/frontend/src/components/common/modalWrapper/modalWrapper.jsx
+++ b/frontend/src/components/common/modalWrapper/modalWrapper.jsx
@@ -1,13 +1,14 @@
-import React from "react";
+import React, { useContext } from "react";
+import { CloseModalContext } from "../../../context/modalContext";
 import styles from "./modalWrapper.module.css";
 
-const ModalWrapper = ({ children, closeModal }) => {
+const ModalWrapper = ({ children }) => {
+  const closeModal = useContext(CloseModalContext);
   const onBackgroundClickHandler = (e) => {
     if (e.target.id === "modalWrapper") {
       closeModal();
     }
   };
-
   return (
     <div
       id="modalWrapper"

--- a/frontend/src/components/habitDetailModal/habitDetailModal.jsx
+++ b/frontend/src/components/habitDetailModal/habitDetailModal.jsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useContext } from "react";
+import { CloseModalContext } from "../../context/modalContext";
 import styles from "./habitDetailModal.module.css";
 
-const HabitDetailModal = ({ currentCard, closeModal, deleteCard }) => {
+const HabitDetailModal = ({ currentCard, deleteCard }) => {
+  const closeModal = useContext(CloseModalContext);
   const { name, identity, description } = currentCard;
   return (
     <div className={styles.container}>

--- a/frontend/src/components/identityDetailModal/identityDetailModal.jsx
+++ b/frontend/src/components/identityDetailModal/identityDetailModal.jsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useContext } from "react";
+import { CloseModalContext } from "../../context/modalContext";
 import styles from "./identityDetailModal.module.css";
 
-const IdentityDetailModal = ({ currentCard, closeModal, deleteCard }) => {
+const IdentityDetailModal = ({ currentCard, deleteCard }) => {
+  const closeModal = useContext(CloseModalContext);
   const { name, description } = currentCard;
   return (
     <div className={styles.container}>

--- a/frontend/src/components/newHabitModal/newHabitModal.jsx
+++ b/frontend/src/components/newHabitModal/newHabitModal.jsx
@@ -3,18 +3,13 @@ import styles from "./newHabitModal.module.css";
 import AddNewForm from "../common/addNewForm/addNewForm";
 import CloseButton from "../closeButton/closeButton";
 
-const NewHabitModal = ({ closeModal, addNewHabit }) => {
+const NewHabitModal = ({ addNewHabit }) => {
   return (
     <article className={styles.container}>
-      <CloseButton closeModal={closeModal} />
+      <CloseButton />
       <div className={styles.contentWrapper}>
         <h2 className={styles.title}>Add New Habit</h2>
-        <AddNewForm
-          type="habit"
-          submitHandler={addNewHabit}
-          // TODO(Jason): use Context for closeModal prop
-          closeModal={closeModal}
-        />
+        <AddNewForm type="habit" submitHandler={addNewHabit} />
         <button className={styles.addButton} form="addHabitForm">
           Add
         </button>

--- a/frontend/src/components/newIdentityModal/newIdentityModal.jsx
+++ b/frontend/src/components/newIdentityModal/newIdentityModal.jsx
@@ -3,18 +3,13 @@ import styles from "./newIdentityModal.module.css";
 import AddNewForm from "../common/addNewForm/addNewForm";
 import CloseButton from "../closeButton/closeButton";
 
-const NewIdentityModal = ({ closeModal, addNewIdentity }) => {
+const NewIdentityModal = ({ addNewIdentity }) => {
   return (
     <article className={styles.container}>
-      <CloseButton closeModal={closeModal} />
+      <CloseButton />
       <div className={styles.contentWrapper}>
         <h2 className={styles.title}>Add New Identity</h2>
-        <AddNewForm
-          type="identity"
-          submitHandler={addNewIdentity}
-          // TODO(Jason): use Context for closeModal prop
-          closeModal={closeModal}
-        />
+        <AddNewForm type="identity" submitHandler={addNewIdentity} />
         <button className={styles.addButton} form="addIdentityForm">
           Add
         </button>

--- a/frontend/src/context/modalContext.js
+++ b/frontend/src/context/modalContext.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+export const OpenModalContext = createContext(null);
+
+export const CloseModalContext = createContext(null);

--- a/frontend/src/context/modalContext.js
+++ b/frontend/src/context/modalContext.js
@@ -1,5 +1,3 @@
 import { createContext } from "react";
 
-export const OpenModalContext = createContext(null);
-
 export const CloseModalContext = createContext(null);


### PR DESCRIPTION
Issue: closeModal function was passed down to too deeply where some parents were not related
Solution: Turn closeModal into context
Risk: No risk
Reviewed by: Jason Ko